### PR TITLE
Fix/use unterminated envs only

### DIFF
--- a/library/elasticbeanstalk_env.py
+++ b/library/elasticbeanstalk_env.py
@@ -138,8 +138,8 @@ def describe_env(ebs, app_name, env_name):
     if len(envs) > 1:
         for env in envs:
             if env['Status'] != “Terminated":
-                return env            
-        return envs
+                return env
+        return None
     if len(envs) == 1:
         return envs[0]
     else:

--- a/library/elasticbeanstalk_env.py
+++ b/library/elasticbeanstalk_env.py
@@ -136,6 +136,9 @@ def describe_env(ebs, app_name, env_name):
     envs = result["DescribeEnvironmentsResponse"]["DescribeEnvironmentsResult"]["Environments"]
 
     if len(envs) > 1:
+        for env in envs:
+            if env['Status'] != “Terminated":
+                return env            
         return envs
     if len(envs) == 1:
         return envs[0]


### PR DESCRIPTION
The current describe_env would returns list of environment if the number of environments are greater than 1. The number of environments normally do not become more than one but when the environment is deleted, the environment remains visible for 1 hour and during that time if you try to create the environment, the describe_env will return the list with both newly created and recently terminated environments. This causes parsing error while checking for variables in env. 
