### PR TITLE
Adding the option to forcefully delete the application

### DIFF
--- a/library/elasticbeanstalk_app.py
+++ b/library/elasticbeanstalk_app.py
@@ -143,7 +143,7 @@ def main():
         if app is None:
             result = dict(changed=False, output='Application not found')
         else:
-            ebs.delete_application(app_name)
+            ebs.delete_application(app_name, terminate_env_by_force=True)
             result = dict(changed=True, app=app)
 
     else:


### PR DESCRIPTION
Currently the delete_application function errors out if the application in question is running.
Adding this option will forcefully stop the application( terminate the application ) before deleting it.
