### PR TITLE
Details and Status

### DIFF
--- a/library/elasticbeanstalk_env.py
+++ b/library/elasticbeanstalk_env.py
@@ -120,6 +120,9 @@ def wait_for(ebs, app_name, env_name, wait_timeout, testfunc):
 
         time.sleep(15)
 
+def status_is_ready(env):
+    return env["Status"] == "Ready"
+
 def health_is_green(env):
     return env["Health"] == "Green"
 
@@ -292,7 +295,7 @@ def main():
                               option_setting_tups, None, tier_name,
                               tier_type, '1.0')
 
-            env = wait_for(ebs, app_name, env_name, wait_timeout, health_is_green)
+            env = wait_for(ebs, app_name, env_name, wait_timeout, status_is_ready)
             result = dict(changed=True, env=env)
         except Exception, err:
             error_msg = boto_exception(err)
@@ -315,7 +318,7 @@ def main():
                                        options_to_remove=None)
 
                 wait_for(ebs, app_name, env_name, wait_timeout, health_is_grey)
-                env = wait_for(ebs, app_name, env_name, wait_timeout, health_is_green)
+                env = wait_for(ebs, app_name, env_name, wait_timeout, status_is_ready)
 
                 result = dict(changed=True, env=env, updates=updates)
             else:


### PR DESCRIPTION
Use Status instead of Health to determine if an environment is ready for changes.
A new application with no version will have a Status of 'Ready' and a Health of 'Red'. This will allow a version to be deployed.

Add a choice of 'details' to elasticbeanstalk_env; this allows detailed reporting of the config for the selected environment.
