### PR TITLE
Update elasticbeanstalk_env.py

### DIFF
--- a/library/elasticbeanstalk_env.py
+++ b/library/elasticbeanstalk_env.py
@@ -184,7 +184,7 @@ def terminated(env):
     return env["Status"] == "Terminated"
 
 def describe_env(ebs, app_name, env_name, ignored_statuses):
-    environment_names = [] if env_name is None else [env_name]
+    environment_names = [env_name] if not isinstance(env_name, list) else env_name
 
     result = ebs.describe_environments(ApplicationName=app_name, EnvironmentNames=environment_names)
     envs = result["Environments"]


### PR DESCRIPTION
Fixes #26 ebs.describe_environments is not returning any environments, even when env_name is an existing environment