### PR TITLE
if the option does not contain Value key, it fails, this should fix t…

### DIFF
--- a/library/elasticbeanstalk_env.py
+++ b/library/elasticbeanstalk_env.py
@@ -243,7 +243,7 @@ def new_or_changed_option(options, setting):
             if (setting['Namespace'] in ['aws:autoscaling:launchconfiguration','aws:ec2:vpc'] and \
                 setting['OptionName'] in ['SecurityGroups', 'ELBSubnets', 'Subnets'] and \
                 set(setting['Value'].split(',')).issubset(setting['Value'].split(','))) or \
-                option["Value"] == setting["Value"]:
+                ('Value' in option and option["Value"] == setting["Value"]):
                 return None
             else:
                 return (option["Namespace"] + ':' + option["OptionName"], option["Value"], setting["Value"])


### PR DESCRIPTION
…he problem

It checks if the option["Value"] exists before trying to compare the option["Value"] with setting["Value"]