### PR TITLE
Vpc handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ The example playbook demonstrates how to create an application and version and u
           env_name: sampleApp-env
           version_label: Sample Application
           solution_stack_name: "64bit Amazon Linux 2014.09 v1.2.1 running Docker 1.5.0"
+          vpc: VPC_NAME
+          vpc_subnets: SUBNET_NAME1,SUBNET_NAME2          
           option_settings:
             - Namespace: aws:elasticbeanstalk:application:environment
               OptionName: PARAM1

--- a/library/elasticbeanstalk_env.py
+++ b/library/elasticbeanstalk_env.py
@@ -397,10 +397,10 @@ def main():
 
     if vpc:
         vpc_id = getVpcId(region, vpc, option_settings, module)
+        module.debug("found vpc_id='{}'".format(vpc_id))
     else:
         vpc_id = None
     
-    module.debug("found vpc_id="+vpc_id)
 
     if vpc_subnets:
         checkVpcSubnetIds(region, vpc_subnets.split(','), vpc_id, option_settings, module)

--- a/library/elasticbeanstalk_env.py
+++ b/library/elasticbeanstalk_env.py
@@ -49,17 +49,17 @@ options:
     default: null
   vpc:
     description:
-      - id or name of the vpc. if not found failure. if found add to option_settings
+      - id or name of vpc. If not found, a ValueError is raised. If found, the vpc_id is added to option_settings
     required: false
     default: null
   vpc_subnets:
     description:
-      - comma seperated list of ids or names from vpc subnets. looks for subnets in previous defined vpc. if no vpc defined it looks over all vpc. if not found failure. if found add to option_settings
+      - comma seperated list of ids or names of vpc subnets. If no subnet is found, a ValueError is raised. If found, but vpc_id is not the same as vpc, a ValueError is raised, else vpc_subnet_id is added to option_settings.
     required: false
     default: null
   option_settings:
     description:
-      - 'A dictionary array of settings to add of the form: { Namespace: ..., OptionName: ... , Value: ... }. If specified, AWS Elastic Beanstalk sets the specified configuration options to the requested value in the configuration set for the new environment. These override the values obtained from the solution stack or the configuration template'
+      - 'An array of dictionaries of the form: { Namespace: ..., OptionName: ... , Value: ... }. If specified, AWS Elastic Beanstalk sets the specified configuration options to the requested value in the configuration set for the new environment. These override the values obtained from the solution stack or the configuration template'
     required: false
     default: null
   tags:
@@ -93,7 +93,7 @@ EXAMPLES = '''
     version_label: Sample Application
     solution_stack_name: "64bit Amazon Linux 2014.09 v1.2.1 running Docker 1.5.0"
     vpc: VPC_NAME
-    vpc_subnets: SUBNET_NAME1, SUBNET_NAME2
+    vpc_subnets: SUBNET_NAME1,SUBNET_NAME2
     option_settings:
       - Namespace: aws:elasticbeanstalk:application:environment
         OptionName: PARAM1

--- a/library/elasticbeanstalk_env.py
+++ b/library/elasticbeanstalk_env.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-from builtins import Exception
 
 DOCUMENTATION = '''
 ---
@@ -152,6 +151,10 @@ try:
 except ImportError:
     HAS_BOTO3 = False
 
+import time
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info, camel_dict_to_snake_dict
+
 def wait_for(ebs, app_name, env_name, wait_timeout, testfunc):
     timeout_time = time.time() + wait_timeout
 
@@ -192,14 +195,15 @@ def describe_env(ebs, app_name, env_name, ignored_statuses):
 
     if not isinstance(envs, list): return None
 
-    if len(envs) == 0: return None
+    if not envs: 
+        return
 
-    print(envs)
     for env in envs:
-        if "Status" in env and env["Status"] in ignored_statuses:
-                envs.remove(env)
+        if env.get("Status") in ignored_statuses:
+            envs.remove(env)
 
-    if len(envs) == 0: return None
+    if not envs: 
+        return
 
     return envs if env_name is None else envs[0]
 
@@ -209,12 +213,12 @@ def describe_env_config_settings(ebs, app_name, env_name):
 
     if not isinstance(envs, list): return None
 
-    print(envs)
     for env in envs:
-        if "Status" in env and env["Status"] in ["Terminated","Terminating"]:
-                envs.remove(env)
+        if env.get("Status") in ["Terminated","Terminating"]:
+            envs.remove(env)
 
-    if len(envs) == 0: return None
+    if not envs:
+        return
 
     return envs if env_name is None else envs[0]
 
@@ -339,14 +343,14 @@ def main():
             env = describe_env(ebs, app_name, env_name, [])
             result = dict(changed=False, env=[] if env is None else env)
         except ClientError as e:
-            module.fail_json(msg=e, **camel_dict_to_snake_dict(e))
+            module.fail_json(msg=str(e), **camel_dict_to_snake_dict(e.response))
 
     if state == 'details':
         try:
             env = describe_env_config_settings(ebs, app_name, env_name)
             result = dict(changed=False, env=env)
         except ClientError as e:
-            module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+            module.fail_json(msg=str(e), **camel_dict_to_snake_dict(e.response))
 
     if module.check_mode and (state != 'list' or state != 'details'):
         check_env(ebs, app_name, env_name, module)
@@ -372,7 +376,7 @@ def main():
             if 'Environment %s already exists' % env_name in e.args:
                 update = True
             else:
-                module.fail_json(msg=e, **camel_dict_to_snake_dict(e.response))
+                module.fail_json(msg=str(e), **camel_dict_to_snake_dict(e.response))
 
     if update:
         try:
@@ -394,7 +398,7 @@ def main():
             else:
                 result = dict(changed=False, env=env)
         except ClientError as e:
-            module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+            module.fail_json(msg=str(e), **camel_dict_to_snake_dict(e.response))
 
     if state == 'absent':
         try:
@@ -405,12 +409,9 @@ def main():
             if 'No Environment found for EnvironmentName = \'%s\'' % env_name in e.message:
                 result = dict(changed=False, output='Environment not found')
             else:
-                module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+                module.fail_json(msg=str(e), **camel_dict_to_snake_dict(e.response))
 
     module.exit_json(**result)
-
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info, camel_dict_to_snake_dict
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Hi 

i added to options to define vpc and vpc_subnets outside from option_settings.
vpc - id or name of vpc. If not found, a ValueError is raised. If found, the vpc_id is added to option_settings

vpc_subnets - comma seperated list of ids or names of vpc subnets. If no subnet is found, a ValueError is raised. If found, but vpc_id is not the same as vpc, a ValueError is raised, else vpc_subnet_id is added to option_settings.

Regards Alex