### PR TITLE
Missed VersionLabel key

### DIFF
--- a/library/elasticbeanstalk_env.py
+++ b/library/elasticbeanstalk_env.py
@@ -169,7 +169,7 @@ def wait_for(ebs, app_name, env_name, wait_timeout, testfunc):
         time.sleep(15)
 
 def version_is_updated(version_label, env):
-    return version_label == ""  or env["VersionLabel"] == version_label
+    return version_label == ""  or env.get("VersionLabel", "") == version_label
 
 def status_is_ready(env):
     return env["Status"] == "Ready"
@@ -215,8 +215,8 @@ def describe_env_config_settings(ebs, app_name, env_name):
 
 def update_required(ebs, env, params):
     updates = []
-    if params["version_label"] and env["VersionLabel"] != params["version_label"]:
-        updates.append(('VersionLabel', env['VersionLabel'], params['version_label']))
+    if params["version_label"] and env.get("VersionLabel", "") != params["version_label"]:
+        updates.append(('VersionLabel', env.get('VersionLabel', ""), params['version_label']))
 
     if params.get("template_name", None) and not env.has_key("TemplateName"):
         updates.append(('TemplateName', None, params['template_name']))


### PR DESCRIPTION
I am creating my cloud infrastructure in AWS with **terraform** and deploying the applications with ansible.
Terraform allows me to create an environment without any version associated. Consequently, the VersionLabel key does not exist in Boto response.



``
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'VersionLabel'
fatal: [127.0.0.1 -> localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_HYWzTw/ansible_module_elasticbeanstalk_env.py\", line 411, in <module>\n    main()\n  File \"/tmp/ansible_HYWzTw/ansible_module_elasticbeanstalk_env.py\", line 375, in main\n    updates = update_required(ebs, env, module.params)\n  File \"/tmp/ansible_HYWzTw/ansible_module_elasticbeanstalk_env.py\", line 218, in update_required\n    if params[\"version_label\"] and env[\"VersionLabel\"] != params[\"version_label\"]:\nKeyError: 'VersionLabel'\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
``
The small changes I made prevent me from the error above and to deploy my first version in beanstalk.